### PR TITLE
Add "await" to be in front of UniswapV2Pair.at() <- When creating deployed contract instance

### DIFF
--- a/test/test-local/GLMStakePool.test.js
+++ b/test/test-local/GLMStakePool.test.js
@@ -186,14 +186,13 @@ contract("GLMStakePool", function(accounts) {
             //await glmStakePool.addLiquidityWithETH(PAIR_GLM_ETH, GLMTokenAmountDesired, { from: user1, value: ETHAmountMin });
         });
 
-        it("Check uniswapV2 Pool balance of GLM-ETH (after addLiquidityETH)", async () => {
+        it("Check pair (GLM-ETH) balance", async () => {
             /// Check pair (GLM-ETH) balance
-            const _PAIR_GLM_ETH = await uniswapV2Factory.getPair(GLM_TOKEN, WETH_TOKEN, { from: user1 });  
-            const uniswapV2Pair = UniswapV2Pair.at(_PAIR_GLM_ETH, { from: user1 });
+            const uniswapV2Pair = await UniswapV2Pair.at(PAIR_GLM_ETH, { from: user1 });
             let _pairBalance = await uniswapV2Pair.balanceOf(user1, { from: user1 });
             let pairBalance = parseFloat(web3.utils.fromWei(_pairBalance));
 
-            console.log('\n=== pair (GLM-ETH) balance of user1 ===', pairBalance);
+            console.log('\n=== pair (GLM-ETH) balance of user1 (after addLiquidityETH) ===', pairBalance);
             // assert.equal();
         });
 


### PR DESCRIPTION
- Add "await" to be in front of UniswapV2Pair.at() <- When creating deployed contract instance
  ↓
   - [Result]
![Screen Shot 2021-01-03 at 17 48 49](https://user-images.githubusercontent.com/19357502/103474954-18492700-4dec-11eb-92e2-c855ffd001e3.png)
